### PR TITLE
Fix for CSPACE-6295: Django SECRET_KEYs need to be secret...and unique per deployment

### DIFF
--- a/cspace_django_site/settings.py
+++ b/cspace_django_site/settings.py
@@ -38,8 +38,8 @@ DATABASES = {
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': '/home/app_webapps/cache/' + PROJECT_NAME + '/images',
-        #'LOCATION': '/tmp/' + PROJECT_NAME + '/images',
+        #'LOCATION': '/home/app_webapps/cache/' + PROJECT_NAME + '/images',
+        'LOCATION': '/tmp/' + PROJECT_NAME + '/images',
         'CULL_FREQUENCY': 10000,
         'OPTIONS': {
             'MAX_ENTRIES': 1000000
@@ -110,7 +110,7 @@ STATICFILES_FINDERS = (
 )
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = '4vzb=dif9s33-dz9y=*0t7se44cpp6fzxu(59b2_ke^yk0ke1%'
+#SECRET_KEY = '4vzb=dif9s33-dz9y=*0t7se44cpp6fzxu(59b2_ke^yk0ke1%'
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
@@ -258,3 +258,11 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
     'authn.authn.CSpaceAuthN',
 )
+
+try:
+    from secret_key import *
+except ImportError:
+    SETTINGS_DIR=os.path.abspath(os.path.dirname(__file__))
+    from utils.secret_key_gen import *
+    generate_secret_key(os.path.join(SETTINGS_DIR, 'secret_key.py'))
+    from secret_key import *

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'ruijing'

--- a/utils/secret_key_gen.py
+++ b/utils/secret_key_gen.py
@@ -1,0 +1,6 @@
+from django.utils.crypto import get_random_string
+
+def generate_secret_key(filename):
+    newfile = open(filename, 'w')
+    chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
+    newfile.write("SECRET_KEY = \"" + get_random_string(50, chars) + "\"")


### PR DESCRIPTION
This is the fix for CSPACE-6295. It is the same as the one deployed already in pahma dev.