### PR TITLE
DJAN-38: fixed /[tenant] ui to match /[tenant]/landing ui

### DIFF
--- a/cspace_django_site/templates/cspace_django_site/loginBtn.html
+++ b/cspace_django_site/templates/cspace_django_site/loginBtn.html
@@ -16,7 +16,7 @@
     {% endblock %}
 {% else %}
     <a href="{% url 'login' %}?next={% url request.resolver_match.view_name %}" id="login" class="prettyBtn">{% trans 'Sign in' %}</a>
-    {% if request.resolver_match.namespace != 'landing' %}
+    {% if request.resolver_match.namespace != 'landing' and request.resolver_match.namespace != '' %}
     <div class="line">
         <div style="display: block;"><a href="{% url 'landing:index' %}" style="margin: 8px 0 0 0; float:right;">All available webapps</a></div>
     </div>


### PR DESCRIPTION
Fix to loginBtn.html so that "All available webapps" don't show on /[tenant], imitating the behavior of /[tenant]/landing